### PR TITLE
Add refinery manager

### DIFF
--- a/YASEL/Classes/RefineryManager.cs
+++ b/YASEL/Classes/RefineryManager.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using VRageMath;
+
+namespace RefineryManager
+{
+    using Grid;
+    using Inventory;
+
+    class RefineryManager
+    {
+        RefineryManagerSettings s;
+
+        public RefineryManager()
+        {
+            s = new RefineryManagerSettings();
+        }
+        public RefineryManager(RefineryManagerSettings settings)
+        {
+            s = settings;
+        }
+
+        public void ManageRefineries()
+        {
+
+        }
+
+        public void LoadRefineries(string fromGroupName, string toGroupName, int stackSize=1000)
+        {
+            var fromCargoBlocks = Grid.GetBlockGrp(fromGroupName);
+            var toRefBlocks = Grid.GetBlockGrp(toGroupName);
+            if (Inventory.CountItems(fromCargoBlocks, "Ore") == 0 || Inventory.GetPercentFull(toRefBlocks) > 0.95) return;
+            
+            var fromCargo = Inventory.GetInventories(fromCargoBlocks);
+            var toRef = new List<IMyInventory>();
+            toRefBlocks.ForEach(refBlock =>
+            {
+                if (refBlock is IMyRefinery)
+                    toRef.Add(refBlock.GetInventory(0));
+            });
+
+            int numberOfOres = 0;
+            fromCargo.ForEach(cargoInv =>
+            {
+                var items = cargoInv.GetItems();
+                if (items.Count > 0)
+                {
+                    items.ForEach(item =>
+                    {
+                        if (item.Content.TypeId.ToString().Contains("Ore"))
+                            numberOfOres++;
+                    });
+                }
+            });
+
+            toRef.ForEach(refInv =>
+            {
+                var refItemCount = refInv.GetItems().Count;
+                IMyInventoryItem firstRefItem = refItemCount>0?refInv.GetItems()[0]:null;
+
+                if ((float)refInv.CurrentVolume / (float)refInv.MaxVolume < 0.95 && 
+                    (refItemCount < numberOfOres || 
+                        (numberOfOres==1 && 
+                        refItemCount == 1 && 
+                        firstRefItem.Amount<(VRage.MyFixedPoint)stackSize*(s.OreMultipliers.ContainsKey(firstRefItem.Content.SubtypeName)?s.OreMultipliers[firstRefItem.Content.SubtypeName]:1)))) 
+                {
+                    fromCargo.ForEach(cargoInv =>
+                    {
+                        var items = cargoInv.GetItems();
+                        if (items.Count > 0)
+                        {
+                            int curIdx = 0;
+                            items.ForEach(item =>
+                            {
+                                if (item.Content.TypeId.ToString().Contains("Ore"))
+                                {
+                                    
+                                    refInv.TransferItemFrom(cargoInv, curIdx, refInv.GetItems().Count, false,
+                                        (VRage.MyFixedPoint)stackSize*(s.OreMultipliers.ContainsKey(item.Content.SubtypeName)?s.OreMultipliers[item.Content.SubtypeName]:1));
+                                }
+                                curIdx++;
+                            });
+                           
+                        }
+                    });
+                }
+            });
+
+
+        }
+    }
+    class RefineryManagerSettings
+    {
+        public Dictionary<string, float> OreMultipliers;
+        public RefineryManagerSettings()
+        {
+            OreMultipliers = new Dictionary<string, float>();
+            OreMultipliers.Add("Uranium", 0.5f);
+            OreMultipliers.Add("Platinum", 0.33f);
+            OreMultipliers.Add("Gold", 0.75f);
+            OreMultipliers.Add("Magnesium", 0.33f);
+            OreMultipliers.Add("Silver", 1f);
+            OreMultipliers.Add("Iron", 1f);
+            OreMultipliers.Add("Cobalt", 0.01f);
+            OreMultipliers.Add("Nickle", 0.33f);
+            OreMultipliers.Add("Silicon", 0.33f);
+            
+        }
+    }
+}

--- a/YASEL/Programs/RefineryManagerProgram.cs
+++ b/YASEL/Programs/RefineryManagerProgram.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using VRageMath;
+
+namespace RefineryManagerProgram
+{
+
+    using Grid;
+    using RefineryManager;
+
+    class RefineryManagerProgram : MyGridProgram
+    {
+
+        void Main(string argument)
+        {
+            Grid.Set(this);
+            var rm = new RefineryManager();
+            rm.LoadRefineries("Ore For Productivity","Productive Refineries", 1000);
+            rm.LoadRefineries("Ore For Effectiveness", "Effective Refineries", 100);
+        }
+
+    }
+}

--- a/YASEL/YASEL.csproj
+++ b/YASEL/YASEL.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Classes\StationManager.cs" />
     <Compile Include="Classes\Disassembler.cs" />
     <Compile Include="Classes\ShipManager.cs" />
+    <Compile Include="Classes\RefineryManager.cs" />
     <Compile Include="Helpers\Airvent.cs" />
     <Compile Include="Helpers\Battery.cs" />
     <Compile Include="Helpers\Block.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="Programs\StationManagerProgram.cs" />
     <Compile Include="Programs\ShipManagerProgram.cs" />
     <Compile Include="Programs\DisassemblerProgram.cs" />
+    <Compile Include="Programs\RefineryManagerProgram.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
Refinery manager has LoadRefineries function to transfer ores to the
refinery in small stacks so that one ore doesn't clog up the system.
First argument is a group name of cargos where ores are stored
Second argument is the group name of refineries.
Third argument is the base stack size, these are multiplied by the
numbers defined in RefineryManagerSettings and can be customised.
